### PR TITLE
Three minor bugfixes

### DIFF
--- a/palimpsest.el
+++ b/palimpsest.el
@@ -122,5 +122,5 @@ option `scroll-bar-mode'."
   :global nil
   :group 'palimpsest)
 
-(provide 'palimpsest-mode)
+(provide 'palimpsest)
  ;;; palimpsest-mode.el ends here


### PR DESCRIPTION
Fixed the defgroup definition by adding a parent group :group 'convenience

Two changes to (provide 'palimpest-mode). First, fixed the missing 's' type and then changed to (provide 'palimpsest) in order to match the filename. Now palimpest can be required with (require 'palimpsest).
