### PR TITLE
Add a configurable prefix for each snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ You are able to:
 - Change the location where text is moved (default is bottom).
 - Define your preferred suffix for the *trash* (or *draft*) file.
 
+A prefix can be added to each palimpsest snippet by setting
+=palimpsest-prefix=. For example, to prefix each snippet with a dash, the
+following could be added to your configuration:
+
+	 (setq 'palimpsest-prefix "- ")
+
 P.S. [Follow][follow_me] me on Twitter.
 
 [follow_me]: https://twitter.com/intent/user?screen_name=danielszmu "Follow @danielszmu"

--- a/palimpsest.el
+++ b/palimpsest.el
@@ -44,6 +44,8 @@
 
 (defconst palimpsest-keymap (make-sparse-keymap) "Keymap used in palimpsest mode.")
 
+(defvar palimpsest-prefix "")
+
 (defun palimpsest-move-region-to-trash (start end)
   "Move text between START and END to associated trash buffer."
   (interactive "r")
@@ -78,6 +80,7 @@
     (save-excursion
       (kill-region start end)
       (goto-char (funcall dest))
+      (insert palimpsest-prefix)
       (yank)
       (newline))
     (push-mark (point))

--- a/palimpsest.el
+++ b/palimpsest.el
@@ -44,8 +44,6 @@
 
 (defconst palimpsest-keymap (make-sparse-keymap) "Keymap used in palimpsest mode.")
 
-(defvar palimpsest-prefix "")
-
 (defun palimpsest-move-region-to-trash (start end)
   "Move text between START and END to associated trash buffer."
   (interactive "r")
@@ -130,6 +128,11 @@
 
 (defcustom palimpsest-trash-file-suffix ".trash"
   "This is the suffix for the trash filename."
+  :group 'palimpsest
+  :type '(string))
+
+(defcustom palimpsest-prefix ""
+  "Prefix the yanked text snippet with a customizable string."
   :group 'palimpsest
   :type '(string))
 


### PR DESCRIPTION
Users may wish to prepend each palimpsest snippet with some kind of marking to
help keep these snippets organized. This could be a comment character, a bullet,
a heading, etc. This commit works by adding the new variable
`palimpsest-prefix`, which defaults to the empty string, and inserting this
prefix before yanking the palimpsest text snippet. This variable
is not used anywhere else, so there should be no side-effects.